### PR TITLE
Remove ACQ_MODE underscore in DwfAnalogIn acquisition mode calls

### DIFF
--- a/dwf/api.py
+++ b/dwf/api.py
@@ -263,11 +263,11 @@ class DwfAnalogIn(Dwf):
 
     def acquisitionModeInfo(self):
         return _make_set(
-            _l.FDwfAnalogInAcquisitionModeInfo(self.hdwf), self.ACQ_MODE)
+            _l.FDwfAnalogInAcquisitionModeInfo(self.hdwf), self.ACQMODE)
     def acquisitionModeSet(self, acqmode):
         _l.FDwfAnalogInAcquisitionModeSet(self.hdwf, acqmode)
     def acquisitionModeGet(self):
-        return self.ACQ_MODE(_l.FDwfAnalogInAcquisitionModeGet(self.hdwf))
+        return self.ACQMODE(_l.FDwfAnalogInAcquisitionModeGet(self.hdwf))
 
 # Channel configuration:
     def channelCount(self):


### PR DESCRIPTION
Bug fix for DwfAnalogIn acquisitionModeGet and Info methods

```
>>> b.acquisitionModeGet()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xes/development/jkobor/venv/lib/python3.5/site-packages/dwf/api.py", line 270, in acquisitionModeGet
    return self.ACQ_MODE(_l.FDwfAnalogInAcquisitionModeGet(self.hdwf))
AttributeError: 'DwfAnalogIn' object has no attribute 'ACQ_MODE'
'DwfAnalogIn' object has no attribute 'ACQ_MODE'
```