### PR TITLE
Correct namespace of IsBitSet reference in _make_set function

### DIFF
--- a/dwf/api.py
+++ b/dwf/api.py
@@ -35,7 +35,7 @@ from . import lowlevel as _l
 def _make_set(value, enum):
     result = []
     for e in list(enum):
-        if IsBitSet(value, e.value):
+        if _l.IsBitSet(value, e.value):
             result.append(e)
     return frozenset(result)
 


### PR DESCRIPTION
Bug fix for IsBitSet function call inside _make_set function

```
>>> ad.scope.ai.acquisitionModeInfo()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xes/development/jkobor/dwf/dwf/api.py", line 266, in acquisitionModeInfo
    _l.FDwfAnalogInAcquisitionModeInfo(self.hdwf), self.ACQMODE)
  File "/home/xes/development/jkobor/dwf/dwf/api.py", line 38, in _make_set
    if IsBitSet(value, e.value):
NameError: name 'IsBitSet' is not defined
name 'IsBitSet' is not defined
```