### PR TITLE
fixed possible rgdVoltData_or_cdData non-int datatype

### DIFF
--- a/dwf/lowlevel.py
+++ b/dwf/lowlevel.py
@@ -408,7 +408,7 @@ def FDwfAnalogInStatusData(hdwf, idxChannel,
     if cdData is not None:
         return _FDwfAnalogInStatusData(hdwf, idxChannel,
                                        rgdVoltData_or_cdData, cdData)
-    cdData = rgdVoltData_or_cdData
+    cdData = int(rgdVoltData_or_cdData)
     rgdVoltData = (c_double * cdData)()
     _FDwfAnalogInStatusData(hdwf, idxChannel, rgdVoltData, cdData)
     return tuple(rgdVoltData)


### PR DESCRIPTION
at one point during use of the api the rgdVoltData_or_cdData value was a float, like 594.0, so converting to int looks to have helped.  by the way many thanks for this awesome API!